### PR TITLE
Fixed VM snapshot extension test failure - Expected <10> to be less than <10>, but was not

### DIFF
--- a/microsoft/testsuites/vm_extensions/vmsnapshot_extension.py
+++ b/microsoft/testsuites/vm_extensions/vmsnapshot_extension.py
@@ -265,7 +265,6 @@ class VmSnapsotLinuxBVTExtension(TestSuite):
                 else:
                     raise e
             time.sleep(1)
-            count = count + 1
         assert_that(count, "Restore point creation failed.").is_less_than(10)
 
     def _find_extension_dir(self, node: Node) -> str:


### PR DESCRIPTION
vmsnapshot_extension test was failing due AssertionError: [Restore point creation failed.] Expected <10> to be less than <10>, but was not.
For this, have removed redundant count increment from the func _verify_vmsnapshot_extension and it is passing